### PR TITLE
Fixed configuration key of the experimental feature flag.

### DIFF
--- a/edge-modules/metrics-collector/src/Settings.cs
+++ b/edge-modules/metrics-collector/src/Settings.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                     configuration.GetValue<UploadTarget>("UploadTarget", UploadTarget.AzureMonitor),
                     configuration.GetValue<bool>("CompressForUpload", true),
                     configuration.GetValue<bool>("TransformForIoTCentral", false),
-                    configuration.GetValue<bool>("experimentalFeatures__AddIdentifyingTags", false),
+                    configuration.GetValue<bool>("experimentalFeatures:AddIdentifyingTags", false),
                     configuration.GetValue<string>("AllowedMetrics", ""),
                     configuration.GetValue<string>("BlockedMetrics", ""),
                     configuration.GetValue<string>("ResourceID", ""),


### PR DESCRIPTION
Fixed configuration key of the experimental feature flag (a environment variable called "experimentalFeatures__AddIdentifyingTags" results in the key "experimentalFeatures:AddIdentifyingTags").
https://docs.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider

Fixes my previous PR.
https://github.com/Azure/iotedge/pull/6114#discussion_r891470429